### PR TITLE
Implement level-fetching; fix readability at 0% progress

### DIFF
--- a/lib/queries.js
+++ b/lib/queries.js
@@ -55,7 +55,7 @@ var addUser = (userData, callback) =>
 		if (err) { console.log("ALERT: Hashing error."); }
 		else
 		{
-			db.none(prepSQL(sql), [userData.fullname, userData.username, hash])
+			db.none(prepSQL(sql), [userData.fullname, userData.username, hash, userData.level, userData.logins, userData.posts, userData.goals])
 			.then(() =>
 			{
 				callback(true);
@@ -353,3 +353,21 @@ var getUserData = (uname, callback) =>
 }
 
 exports.getUserData = getUserData;
+
+var getLevel = (uname, callback) =>
+{
+	var sql = fs.readFileSync(path.join(__dirname + '/sql/get_level.sql')).toString();
+
+	db.any(prepSQL(sql), [uname])
+	.then((response) =>
+	{
+		return callback(response[0].level);
+	})
+	.catch((error) =>
+	{
+		console.log(error);
+		return callback(false);
+	});
+}
+
+exports.getLevel = getLevel;

--- a/lib/sql/create_new_user.sql
+++ b/lib/sql/create_new_user.sql
@@ -2,11 +2,19 @@ INSERT INTO {SCHEMA}.users(
 	fullname,
 	username,
 	password,
-	last_login
+	last_login,
+	level,
+	logins,
+	posts,
+	goals
 )
 VALUES (
 	$1,
 	$2,
 	$3,
-	current_timestamp
+	current_timestamp,
+	$4,
+	$5,
+	$6,
+	$7
 );

--- a/lib/sql/get_level.sql
+++ b/lib/sql/get_level.sql
@@ -1,0 +1,2 @@
+SELECT level FROM {SCHEMA}.users
+WHERE username = $1;

--- a/public/stylesheets/history.css
+++ b/public/stylesheets/history.css
@@ -15,6 +15,10 @@
 	color: #FF0000;
 	font-size: 2.5em;
 }
+.e {
+	width: 100%;
+	text-align: center;
+}
 
 .post-table table, .post-table td {
 	border: 1.5px solid #000;

--- a/routes/history.js
+++ b/routes/history.js
@@ -5,17 +5,21 @@ var queries = require(path.join('../lib/queries'));
 
 router.get("/", (req, res, next) => {
   if (req.session && req.session.loggedIn) {
-    queries.getMood(req.session.username, (moodData) => {
-      queries.getJournal(req.session.username, (journalData) => {
-        res.render('history', {
-          user: req.session,
-					level: req.session.level,
-          journalPosts: journalData,
-          moodPosts: moodData,
-          achievementMessage: req.session.achievementMessage,
-          displayed: function() {
-            req.session.achievementMessage = "";
-          }
+    queries.getLevel(req.session.username, (ulevel) =>
+    {
+      req.session.level = ulevel;
+      queries.getMood(req.session.username, (moodData) => {
+        queries.getJournal(req.session.username, (journalData) => {
+          res.render('history', {
+            user: req.session,
+            level: req.session.level,
+            journalPosts: journalData,
+            moodPosts: moodData,
+            achievementMessage: req.session.achievementMessage,
+            displayed: function() {
+              req.session.achievementMessage = "";
+            }
+          });
         });
       });
     });

--- a/routes/home.js
+++ b/routes/home.js
@@ -6,13 +6,17 @@ var queries = require(path.join('../lib/queries'));
 router.get("/", (req, res, next) => {
 	if (req.session && req.session.loggedIn)
 	{
-		res.render('home', {
-			user : req.session,
-			level: req.session.level,
-			achievementMessage: req.session.achievementMessage,
-			displayed: function() {
-				req.session.achievementMessage = "";
-			}
+		queries.getLevel(req.session.username, (ulevel) =>
+		{
+			req.session.level = ulevel;
+			res.render('home', {
+				user : req.session,
+				level: req.session.level,
+				achievementMessage: req.session.achievementMessage,
+				displayed: function() {
+					req.session.achievementMessage = "";
+				}
+			});
 		});
 	}
 	else

--- a/routes/index.js
+++ b/routes/index.js
@@ -39,8 +39,8 @@ router.post('/', (req, res, next) => {
         // increment login
         req.session.posts = responseData.posts;
         req.session.goals = responseData.goals;
-        res.redirect('/home');
         rewards.changeLevel(req.session.username, req.session.level, req.session.logins, req.session.posts, req.session.goals);
+        res.redirect('/home');
       } else {
         delete req.session;
         res.redirect('/?failedLogin=true');

--- a/routes/journal.js
+++ b/routes/journal.js
@@ -6,9 +6,13 @@ var rewards = require(path.join('../lib/rewards'));
 
 router.get("/", (req, res, next) => {
   if (req.session && req.session.loggedIn) {
-    res.render('journal', {
-      user: req.session,
-      level: req.session.level
+    queries.getLevel(req.session.username, (ulevel) =>
+    {
+      req.session.level = ulevel;
+      res.render('journal', {
+        user: req.session,
+        level: req.session.level
+      });
     });
   } else {
     res.redirect('/');

--- a/routes/mood.js
+++ b/routes/mood.js
@@ -7,9 +7,13 @@ var rewards = require(path.join('../lib/rewards'));
 
 router.get("/", (req, res, next) => {
   if (req.session && req.session.loggedIn) {
-    res.render('mood', {
-      user: req.session,
-			level: req.session.level
+    queries.getLevel(req.session.username, (ulevel) =>
+    {
+      req.session.level = ulevel;
+      res.render('mood', {
+        user: req.session,
+        level: req.session.level
+      });
     });
   } else {
     res.redirect('/');
@@ -23,9 +27,7 @@ router.post("/", (req, res, next) => {
       console.log("ALERT: Failed to write new journal entry.");
       res.redirect('/mood');
     } else {
-			console.log("printing body", req.body);
       req.session.achievementMessage = "New Mood +10xp";
-      console.log(req.session);
       res.redirect('/history');
       req.session.posts++;
       rewards.changeLevel(req.session.username, req.session.level, req.session.logins, req.session.posts, req.session.goals);

--- a/routes/newgoal.js
+++ b/routes/newgoal.js
@@ -8,7 +8,11 @@ var rewards = require(path.join('../lib/rewards'));
 router.get("/", (req, res, next) => {
 	if (req.session && req.session.loggedIn)
 	{
-		res.render('newgoal', {user : req.session, level: req.session.level});
+		queries.getLevel(req.session.username, (ulevel) =>
+		{
+			req.session.level = ulevel;
+			res.render('newgoal', {user : req.session, level: req.session.level});
+		});
 	}
 	else
 	{

--- a/routes/pastgoals.js
+++ b/routes/pastgoals.js
@@ -8,36 +8,39 @@ router.get("/", (req, res, next) => {
 	// user log-in check
 	if (req.session && req.session.loggedIn)
 	{
-		// check if goal has been moved
-		if (req.query.ts && req.query.status)
+		queries.getLevel(req.session.username, (ulevel) =>
 		{
-			queries.updateGoal(req.session.username, req.query.ts, req.query.status, (success) =>
+			req.session.level = ulevel;
+			// check if goal has been moved
+			if (req.query.ts && req.query.status)
 			{
-				if (!success)
+				queries.updateGoal(req.session.username, req.query.ts, req.query.status, (success) =>
 				{
-					console.log("ALERT: Failed to update goal status.");
-				}
-				res.redirect('/pastgoals');
-				req.session.goals ++;
-				// redirect after db adjustment to have page rendered
-			});
-		}
-		else // if goal hasn't just been moved, render page
-		{
-			queries.getGoals(req.session.username, (goals) => {
-				res.render('pastgoals', {
-					user : req.session,
-					level: req.session.level,
-					goals: goals,
-					achievementMessage: req.session.achievementMessage,
-					displayed: function() {
-						req.session.achievementMessage = "";
+					if (!success)
+					{
+						console.log("ALERT: Failed to update goal status.");
 					}
+					res.redirect('/pastgoals');
+					req.session.goals ++;
+					// redirect after db adjustment to have page rendered
 				});
-				console.log(req.session);
-			});
-		}
-		rewards.changeLevel(req.session.username, req.session.level, req.session.logins, req.session.posts, req.session.goals);
+			}
+			else // if goal hasn't just been moved, render page
+			{
+				queries.getGoals(req.session.username, (goals) => {
+					res.render('pastgoals', {
+						user : req.session,
+						level: req.session.level,
+						goals: goals,
+						achievementMessage: req.session.achievementMessage,
+						displayed: function() {
+							req.session.achievementMessage = "";
+						}
+					});
+				});
+			}
+			rewards.changeLevel(req.session.username, req.session.level, req.session.logins, req.session.posts, req.session.goals);
+		});
 	}
 	else
 	{

--- a/routes/signup.js
+++ b/routes/signup.js
@@ -11,7 +11,11 @@ router.get("/", (req, res, next) => {
 router.post("/", (req, res, next) => {
 	var data = {fullname : req.body.fullname,
 				username : req.body.username,
-				password : req.body.password};
+				password : req.body.password,
+				level : 1,
+				logins : 1,
+				posts : 0,
+				goals : 0};
 
 	if (data.password.length < 6) {
 		res.redirect('/signup?pLengthErr=true');

--- a/routes/views/history.pug
+++ b/routes/views/history.pug
@@ -81,7 +81,7 @@ html(lang='en')
       table
         - var empty = moodPosts.length < 1
         if empty
-          div.error You have not logged your Mood yet!
+          div.error You have not logged your mood yet!
           a.error(href='/mood') [Click here to log your mood]
         else
           tbody

--- a/routes/views/history.pug
+++ b/routes/views/history.pug
@@ -47,7 +47,7 @@ html(lang='en')
       table
         - var empty = journalPosts.length < 1
         if empty
-          div.error You have not posted Journal yet!
+          div.error You have not created a journal entry yet!
           a.error(href='/journal') [Click here to write a new post]
         else
           tbody
@@ -81,8 +81,8 @@ html(lang='en')
       table
         - var empty = moodPosts.length < 1
         if empty
-          div.error You have not posted Mood yet!
-          a.error(href='/mood') [Click here to write a new post]
+          div.error You have not logged your Mood yet!
+          a.error(href='/mood') [Click here to log your mood]
         else
           tbody
             tr

--- a/routes/views/home.pug
+++ b/routes/views/home.pug
@@ -34,9 +34,13 @@ html(lang='en')
             .level
               - var prog = Math.ceil((level % 1) * 100)
               - var current = Math.floor(level)
-              p level #{current}
-              .progress
-                .progress-bar(role='progressbar', aria-valuenow=prog, aria-valuemin='0', aria-valuemax='100', style='width:' + prog + '%') #{prog}%
+              if prog != 0
+                p level #{current}
+                .progress
+                  .progress-bar(role='progressbar', aria-valuenow=prog, aria-valuemin='0', aria-valuemax='100', style='width:' + prog + '%') #{prog}%
+              else
+                p level #{current}, 0%
+
             a.dropdown-item(href='/logout') Log Out
     .content
       h2#welcome-back Welcome back, #{user.username}

--- a/routes/views/journal.pug
+++ b/routes/views/journal.pug
@@ -32,7 +32,7 @@ html(lang='en')
                             p level #{current}
                             .progress
                               .progress-bar(role='progressbar', aria-valuenow=prog, aria-valuemin='0', aria-valuemax='100', style='width:' + prog + '%') #{prog}%
-                          else
+                        else
                             p level #{current}, 0%
         .form-content
             form.form-feeling(method='POST', action='/journal')

--- a/routes/views/journal.pug
+++ b/routes/views/journal.pug
@@ -28,10 +28,12 @@ html(lang='en')
                       .level
                         - var prog = Math.ceil((level % 1) * 100)
                         - var current = Math.floor(level)
-                        p level #{current}
-                        .progress
-                            .progress-bar(role='progressbar', aria-valuenow=prog, aria-valuemin='0', aria-valuemax='100', style='width:' + prog + '%') #{prog}%
-                      a.dropdown-item(href='/logout') Log Out
+                        if prog != 0
+                            p level #{current}
+                            .progress
+                              .progress-bar(role='progressbar', aria-valuenow=prog, aria-valuemin='0', aria-valuemax='100', style='width:' + prog + '%') #{prog}%
+                          else
+                            p level #{current}, 0%
         .form-content
             form.form-feeling(method='POST', action='/journal')
                 p.title New Journal Entry

--- a/routes/views/mood.pug
+++ b/routes/views/mood.pug
@@ -34,7 +34,7 @@ html(lang='en')
                             p level #{current}
                             .progress
                               .progress-bar(role='progressbar', aria-valuenow=prog, aria-valuemin='0', aria-valuemax='100', style='width:' + prog + '%') #{prog}%
-                          else
+                        else
                             p level #{current}, 0%
         .form-content
             form.form-feeling(method="POST", action='/mood')

--- a/routes/views/mood.pug
+++ b/routes/views/mood.pug
@@ -30,10 +30,12 @@ html(lang='en')
                       .level
                         - var prog = Math.ceil((level % 1) * 100)
                         - var current = Math.floor(level)
-                        p level #{current}
-                        .progress
-                            .progress-bar(role='progressbar', aria-valuenow=prog, aria-valuemin='0', aria-valuemax='100', style='width:' + prog + '%') #{prog}%
-                      a.dropdown-item(href='/logout') Log Out
+                        if prog != 0
+                            p level #{current}
+                            .progress
+                              .progress-bar(role='progressbar', aria-valuenow=prog, aria-valuemin='0', aria-valuemax='100', style='width:' + prog + '%') #{prog}%
+                          else
+                            p level #{current}, 0%
         .form-content
             form.form-feeling(method="POST", action='/mood')
                 p.title Mood Tracker

--- a/routes/views/newgoal.pug
+++ b/routes/views/newgoal.pug
@@ -21,6 +21,8 @@ html(lang='en')
             ul.navbar-nav.ml-auto
                 li.nav-item
                     a.nav-link(href='/history') Past Posts
+                li.nav-item
+                    a.nav-link(href='/pastgoals') Goals
                 li.nav-item.dropdown
                     a#navbardrop.nav-link.dropdown-toggle(href='#', data-toggle='dropdown') #{user.username}
                     .dropdown-menu.dropdown-menu-right
@@ -31,7 +33,7 @@ html(lang='en')
                             p level #{current}
                             .progress
                               .progress-bar(role='progressbar', aria-valuenow=prog, aria-valuemin='0', aria-valuemax='100', style='width:' + prog + '%') #{prog}%
-                          else
+                        else
                             p level #{current}, 0%
         .form-content
             form.form-feeling(method='POST', action='/newgoal')

--- a/routes/views/newgoal.pug
+++ b/routes/views/newgoal.pug
@@ -27,10 +27,12 @@ html(lang='en')
                       .level
                         - var prog = Math.ceil((level % 1) * 100)
                         - var current = Math.floor(level)
-                        p level #{current}
-                        .progress
-                            .progress-bar(role='progressbar', aria-valuenow=prog, aria-valuemin='0', aria-valuemax='100', style='width:' + prog + '%') #{prog}%
-                      a.dropdown-item(href='/logout') Log Out
+                        if prog != 0
+                            p level #{current}
+                            .progress
+                              .progress-bar(role='progressbar', aria-valuenow=prog, aria-valuemin='0', aria-valuemax='100', style='width:' + prog + '%') #{prog}%
+                          else
+                            p level #{current}, 0%
         .form-content
             form.form-feeling(method='POST', action='/newgoal')
                 p.title New Goal

--- a/routes/views/pastgoals.pug
+++ b/routes/views/pastgoals.pug
@@ -45,30 +45,35 @@ html(lang='en')
               else
                 p level #{current}, 0%
 
-    div.goal-lists
-      div.goals-list(id="in-progress", ondrop="drop(event)", ondragover="allowDrop(event)")
-        h2 In Progress
-        each goal, ind in goals
-          if goal.in_progress
-            - var timestamp = goal.timestamp
-            div.goal-card(id=ind, draggable='true', value=timestamp, ondragstart="drag(event)")
-              h3 Goal: #{goal.goal}
-              p Complete By: #{goal.duration}
-              p Reward: #{goal.reward}
-              br
-              p.date Created On:#{goal.createdAt}
+    if goals.length != 0
+      div.goal-lists
+        div.goals-list(id="in-progress", ondrop="drop(event)", ondragover="allowDrop(event)")
+          h2 In Progress
+          each goal, ind in goals
+            if goal.in_progress
+              - var timestamp = goal.timestamp
+              div.goal-card(id=ind, draggable='true', value=timestamp, ondragstart="drag(event)")
+                h3 Goal: #{goal.goal}
+                p Complete By: #{goal.duration}
+                p Reward: #{goal.reward}
+                br
+                p.date Created On:#{goal.createdAt}
 
-      div.goals-list(id="completed", ondrop="drop(event)", ondragover="allowDrop(event)")
-        h2 Completed
-        each goal, ind in goals
-          if !goal.in_progress
-            - var timestamp = goal.timestamp
-            div.goal-card(id=ind, draggable='true', value=timestamp, ondragstart="drag(event)")
-              h3 Reward: #{goal.reward}
-              p Goal: #{goal.goal}
-              p Complete By: #{goal.duration}
-              br
-              p.date Created On:#{goal.createdAt}
+        div.goals-list(id="completed", ondrop="drop(event)", ondragover="allowDrop(event)")
+          h2 Completed
+          each goal, ind in goals
+            if !goal.in_progress
+              - var timestamp = goal.timestamp
+              div.goal-card(id=ind, draggable='true', value=timestamp, ondragstart="drag(event)")
+                h3 Reward: #{goal.reward}
+                p Goal: #{goal.goal}
+                p Complete By: #{goal.duration}
+                br
+                p.date Created On:#{goal.createdAt}
+    else
+      div.error You have not created a journal entry yet!
+      div.e
+        a.error(href='/newgoal') [Click here to write a new post]
 
     script(src='/scripts/achievement.js')
     if achievementMessage

--- a/routes/views/pastgoals.pug
+++ b/routes/views/pastgoals.pug
@@ -38,10 +38,12 @@ html(lang='en')
             .level
               - var prog = Math.ceil((level % 1) * 100)
               - var current = Math.floor(level)
-              p level #{current}
-              .progress
-                .progress-bar(role='progressbar', aria-valuenow=prog, aria-valuemin='0', aria-valuemax='100', style='width:' + prog + '%') #{prog}%
-            a.dropdown-item(href='/logout') Log Out
+              if prog != 0
+                p level #{current}
+                .progress
+                  .progress-bar(role='progressbar', aria-valuenow=prog, aria-valuemin='0', aria-valuemax='100', style='width:' + prog + '%') #{prog}%
+              else
+                p level #{current}, 0%
 
     div.goal-lists
       div.goals-list(id="in-progress", ondrop="drop(event)", ondragover="allowDrop(event)")


### PR DESCRIPTION
- Write logical default values to database when a new user is created, rather than using null
- Only show progress bar when progress has been made, making the percentage value easier to read
- Only show goal tables when the user has goals, otherwise prompt the user to create a new one 
- Fetch current level from the database when loading pages, to make sure the value shown to the user stays up-to-date